### PR TITLE
feat: export wso2 type definitions

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -8,6 +8,8 @@ export * from './apigateway/types';
 export { BaseNodeJsFunction } from './lambda/lambda-base';
 export * from './lambda/types';
 
+export type { Wso2LambdaConfig, Wso2Config } from './wso2/types';
+
 export { Wso2Api } from './wso2/wso2-api/wso2-api';
 export * from './wso2/wso2-api/types';
 


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

- [X] Exposes the `Wso2LambdaConfig` type definition.
- [X] Exposes the `Wso2Config` type definition.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

In my project we are doing a couple parametrisation throughout our common resources used by each individual service, so it is very handy to have those properties exposed directly.

## Breaking changes

None

## Closing issues

None
