### PR TITLE
fix: use vpc prop as fallback

### DIFF
--- a/lib/src/lambda/lambda-base.ts
+++ b/lib/src/lambda/lambda-base.ts
@@ -112,7 +112,7 @@ export const getPropsWithDefaults = (
   props: BaseNodeJsProps,
   scope: Construct,
 ): BaseNodeJsProps => {
-  let vpc: IVpc | undefined;
+  let vpc: IVpc | undefined = props.vpc;
   if (props.network) {
     if (props.vpc) {
       throw new Error(`'vpc' is not supported when defining 'network'`);


### PR DESCRIPTION
## Summary

If `props.network` is not provided, I would expect that it takes the original NodeJsFunction props `props.vpc`.
However, the value of`vpc` remains `null`. I suspect this is a bug.

To fix this, I set `props.vpc` as a fallback value (this will be overridden in the next lines if `props.network` is provided).