### PR TITLE
feat: add stage name to the api gateway

### DIFF
--- a/lib/src/apigateway/openapi-gateway-lambda.ts
+++ b/lib/src/apigateway/openapi-gateway-lambda.ts
@@ -120,6 +120,7 @@ const addLogGroupForTracing = (
     });
 
     const deployOptionsAccessLog: StageOptions = {
+      stageName: props.stage,
       ...props.deployOptions,
       accessLogDestination: new LogGroupLogDestination(logGroupAccessLog),
       accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
@@ -133,8 +134,9 @@ const addLogGroupForTracing = (
   }
 
   return {
-    deployOptions: props.deployOptions ?? {
-      metricsEnabled: true,
+    deployOptions: {
+      stageName: props.stage,
+      ...(props.deployOptions ? props.deployOptions : { metricsEnabled: true }),
     },
   };
 };


### PR DESCRIPTION
## Summary

Currently we are creating the api in the api-gateway with the `prod` stage, because it is the default value.
But we should match the api stage with the `props.stage` then we're really creating an staged api.

The user can still override the `stageName` by passing it via construct's prop.

# TODO: Create unit tests