### PR TITLE
feat: add ssm param as input to log group subscriber lambda

### DIFF
--- a/docs/base-nodejs-lambda.md
+++ b/docs/base-nodejs-lambda.md
@@ -8,7 +8,7 @@ Based on [AWS Construct NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/d
   - explicit private VPC configuration (see props.network)
   - source code path standardization to "[basePath]/[lambdaEventType]/[lambdaName]/index.ts" (can be overwritten by explicit props.entry)
   - custom CA support for HTTP calls (NodeJS NODE_EXTRA_CA_CERTS). See props.extraCaPubCert
-  - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriberLambdaArn
+  - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriber
   - adds environment STAGE to Lambda. See props.stage
 
 ### Usage
@@ -60,8 +60,16 @@ Based on [AWS Construct NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/d
 
     // register an external Lambda to receive all Cloudwatch log events 
     // created by this Lambda (used to forward logs to Datadog, Splunk etc)
-    lambdaConfig.logGroupSubscriberLambdaArn =
-      'arn:aws:lambda:eu-west-1:012345678:function:datadogForwarder';
+    lambdaConfig.logGroupSubscriber = {
+        type: logGroupSubscriberType.Arn,
+        value: 'arn:aws:lambda:eu-west-1:012345678:function:datadogForwarder',
+    };
+
+    // You can also provide a key of an system manager's parameter store with type string
+    lambdaConfig.logGroupSubscriber = {
+        type: logGroupSubscriberType.Ssm,
+        value: 'datadog-forwarder-lambda-arn',
+    };
 
     // instantiate Lambda construct
     const func = new BaseNodeJsFunction(stack, 'test-lambda', lambdaConfig);

--- a/docs/base-nodejs-lambda.md
+++ b/docs/base-nodejs-lambda.md
@@ -8,7 +8,7 @@ Based on [AWS Construct NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/d
   - explicit private VPC configuration (see props.network)
   - source code path standardization to "[basePath]/[lambdaEventType]/[lambdaName]/index.ts" (can be overwritten by explicit props.entry)
   - custom CA support for HTTP calls (NodeJS NODE_EXTRA_CA_CERTS). See props.extraCaPubCert
-  - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriber
+  - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriberArn
   - adds environment STAGE to Lambda. See props.stage
 
 ### Usage
@@ -60,14 +60,15 @@ Based on [AWS Construct NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/d
 
     // register an external Lambda to receive all Cloudwatch log events 
     // created by this Lambda (used to forward logs to Datadog, Splunk etc)
-    lambdaConfig.logGroupSubscriber = {
-        type: logGroupSubscriberType.Arn,
+    lambdaConfig.logGroupSubscriberArn = {
+        type: LogGroupSubscriberArnType.Arn,
         value: 'arn:aws:lambda:eu-west-1:012345678:function:datadogForwarder',
     };
 
-    // You can also provide a key of an system manager's parameter store with type string
-    lambdaConfig.logGroupSubscriber = {
-        type: logGroupSubscriberType.Ssm,
+    // You can also provide an AWS Systems Manager Parameter Store name that points
+    // to the Arn of the Lambda function that will subscribe to the log group
+    lambdaConfig.logGroupSubscriberArn = {
+        type: LogGroupSubscriberArnType.Ssm,
         value: 'datadog-forwarder-lambda-arn',
     };
 

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -3658,7 +3658,7 @@ packages:
       function.prototype.name: 1.1.6
       get-intrinsic: 1.2.4
       get-symbol-description: 1.0.2
-      globalthis: 1.0.3
+      globalthis: 1.0.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
       has-proto: 1.0.3
@@ -4595,6 +4595,14 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       define-properties: 1.2.1
+
+  /globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.0.1
+    dev: true
 
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -7435,7 +7443,7 @@ packages:
     dev: false
 
   file:../lib/dist/cdk-practical-constructs-0.0.1.tgz:
-    resolution: {integrity: sha512-gXjZwZHWGDW2reetEi45Y/bJSUatRs4s8wNDdvqgwyQ6fIlgEj+1L3brOpaAwJt4Z5vt6xk8tMekcdhoYWj2uw==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+    resolution: {integrity: sha512-auYtvvAuy2A8tAikJXEFFIph2DwpRcRyGgcoQMnraTDc2YJ2pO0Qamq9keGQNkco5bJIoot6jckS0D3MI3r2bg==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
     name: cdk-practical-constructs
     version: 0.0.1
     dependencies:

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -3887,7 +3887,7 @@ packages:
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
-      get-tsconfig: 4.7.3
+      get-tsconfig: 4.7.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
     transitivePeerDependencies:
@@ -4540,8 +4540,8 @@ packages:
       get-intrinsic: 1.2.4
     dev: true
 
-  /get-tsconfig@4.7.3:
-    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
+  /get-tsconfig@4.7.4:
+    resolution: {integrity: sha512-ofbkKj+0pjXjhejr007J/fLf+sW+8H7K5GCm+msC8q3IpvgjobpyPqSRFemNyIMxklC0zeJpi7VDFna19FacvQ==}
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true
@@ -7443,7 +7443,7 @@ packages:
     dev: false
 
   file:../lib/dist/cdk-practical-constructs-0.0.1.tgz:
-    resolution: {integrity: sha512-auYtvvAuy2A8tAikJXEFFIph2DwpRcRyGgcoQMnraTDc2YJ2pO0Qamq9keGQNkco5bJIoot6jckS0D3MI3r2bg==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+    resolution: {integrity: sha512-tBhkseT6lrE43U9k91q1sJnkqdBayic2SCCRWwcQL3cRz/bE5MzYhJR/ZuAmDMCUOVAQM6TmTQlDRi3HHMZPGA==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
     name: cdk-practical-constructs
     version: 0.0.1
     dependencies:

--- a/examples/src/lambda/cdk.ts
+++ b/examples/src/lambda/cdk.ts
@@ -6,7 +6,7 @@ import {
   BaseNodeJsProps,
   EventType,
   vpcFromConfig,
-  LogGroupSubscriberType,
+  LogGroupSubscriberArnType,
 } from 'cdk-practical-constructs';
 import { Construct } from 'constructs';
 
@@ -39,8 +39,8 @@ export const addLambdaGetTest = (scope: Construct): void => {
   customSG.addIngressRule(Peer.ipv4('9.9.9.9/32'), Port.allTraffic(), 'allow ingress');
   customSG.addEgressRule(Peer.ipv4('8.8.8.8/32'), Port.allTraffic(), 'allow egress');
   lambdaConfig.securityGroups = [customSG];
-  lambdaConfig.logGroupSubscriber = {
-    type: LogGroupSubscriberType.Arn,
+  lambdaConfig.logGroupSubscriberArn = {
+    type: LogGroupSubscriberArnType.Arn,
     value: 'arn:aws:lambda:eu-west-1:012345678:function:tstLogging',
   };
 

--- a/examples/src/lambda/cdk.ts
+++ b/examples/src/lambda/cdk.ts
@@ -6,6 +6,7 @@ import {
   BaseNodeJsProps,
   EventType,
   vpcFromConfig,
+  LogGroupSubscriberType,
 } from 'cdk-practical-constructs';
 import { Construct } from 'constructs';
 
@@ -38,8 +39,10 @@ export const addLambdaGetTest = (scope: Construct): void => {
   customSG.addIngressRule(Peer.ipv4('9.9.9.9/32'), Port.allTraffic(), 'allow ingress');
   customSG.addEgressRule(Peer.ipv4('8.8.8.8/32'), Port.allTraffic(), 'allow egress');
   lambdaConfig.securityGroups = [customSG];
-  lambdaConfig.logGroupSubscriberLambdaArn =
-    'arn:aws:lambda:eu-west-1:012345678:function:tstLogging';
+  lambdaConfig.logGroupSubscriber = {
+    type: LogGroupSubscriberType.Arn,
+    value: 'arn:aws:lambda:eu-west-1:012345678:function:tstLogging',
+  };
 
   const func = new BaseNodeJsFunction(scope, 'getTest', lambdaConfig);
   if (!func.defaultSecurityGroup) throw new Error('defaultSecurityGroup should be defined');

--- a/lib/src/lambda/lambda-base.test.ts
+++ b/lib/src/lambda/lambda-base.test.ts
@@ -8,7 +8,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 import { vpcFromConfig } from '../utils';
 
-import { BaseNodeJsProps, EventType, LogGroupSubscriberType } from './types';
+import { BaseNodeJsProps, EventType, LogGroupSubscriberArnType } from './types';
 import { BaseNodeJsFunction } from './lambda-base';
 
 describe('lambda-base', () => {
@@ -46,8 +46,8 @@ describe('lambda-base', () => {
     customSG.addIngressRule(Peer.ipv4('9.9.9.9/32'), Port.allTraffic(), 'allow ingress');
     customSG.addEgressRule(Peer.ipv4('8.8.8.8/32'), Port.allTraffic(), 'allow egress');
     lambdaConfig.securityGroups = [customSG];
-    lambdaConfig.logGroupSubscriber = {
-      type: LogGroupSubscriberType.Arn,
+    lambdaConfig.logGroupSubscriberArn = {
+      type: LogGroupSubscriberArnType.Arn,
       value: 'arn:aws:lambda:eu-west-1:012345678:function:tstLogging',
     };
 
@@ -132,8 +132,8 @@ describe('lambda-base', () => {
       stage: 'dev',
       eventType: EventType.Http,
       baseCodePath: 'src/apigateway/__tests__',
-      logGroupSubscriber: {
-        type: LogGroupSubscriberType.Ssm,
+      logGroupSubscriberArn: {
+        type: LogGroupSubscriberArnType.Ssm,
         value: 'log-forwarder-lambda-arn',
       },
     };

--- a/lib/src/lambda/lambda-base.ts
+++ b/lib/src/lambda/lambda-base.ts
@@ -14,10 +14,11 @@ import {
 } from 'aws-cdk-lib/aws-applicationautoscaling';
 import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { RemovalPolicy } from 'aws-cdk-lib';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 import { vpcFromConfig } from '../utils';
 
-import { BaseNodeJsProps, LambdaConfig } from './types';
+import { BaseNodeJsProps, LambdaConfig, LogGroupSubscriberType } from './types';
 
 // CDK L2 constructs
 // Docs: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html#entry
@@ -33,7 +34,7 @@ import { BaseNodeJsProps, LambdaConfig } from './types';
  *   - allowAllOutbound is false by default. Use allowOutboundTo to specify hosts
  *   - source code path standardization to "[basePath]/[lambdaEventType]/[lambdaName]/index.ts" (can be overwritten by explicit props.entry)
  *   - custom CA support for HTTP calls (NodeJS NODE_EXTRA_CA_CERTS). See props.extraCaPubCert
- *   - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriberLambdaArn
+ *   - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriber
  *   - adds environment STAGE to Lambda. See props.stage
  */
 export class BaseNodeJsFunction extends Construct {
@@ -136,10 +137,8 @@ export const getPropsWithDefaults = (
     // eslint-disable-next-line prefer-destructuring
     createDefaultLogGroup = props.createDefaultLogGroup;
   }
-  if (!createDefaultLogGroup && props.logGroupSubscriberLambdaArn) {
-    throw new Error(
-      `'logGroupSubscriberLambdaArn' cannot be used if 'createDefaultLogGroup' is false`,
-    );
+  if (!createDefaultLogGroup && props.logGroupSubscriber) {
+    throw new Error(`'logGroupSubscriber' cannot be used if 'createDefaultLogGroup' is false`);
   }
 
   let { entry } = props;
@@ -255,14 +254,20 @@ const addLogSubscriber = (
   nodeJsFunction: NodejsFunction,
   props: LambdaConfig,
 ): void => {
-  if (!props.logGroupSubscriberLambdaArn) {
+  if (!props.logGroupSubscriber) {
     return;
   }
+
+  const functionArn =
+    props.logGroupSubscriber.type === LogGroupSubscriberType.Arn
+      ? props.logGroupSubscriber.value
+      : StringParameter.valueForStringParameter(scope, props.logGroupSubscriber.value);
+
   const logGroupFuncSubscriber = Function.fromFunctionAttributes(
     nodeJsFunction,
     'logGroupFuncSubscriber',
     {
-      functionArn: props.logGroupSubscriberLambdaArn,
+      functionArn,
       // https://aleksdaranutsa.medium.com/aws-cdk-cloudwatch-logs-subscription-f4de1f9a52bf
       sameEnvironment: true,
     },

--- a/lib/src/lambda/lambda-base.ts
+++ b/lib/src/lambda/lambda-base.ts
@@ -18,7 +18,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 import { vpcFromConfig } from '../utils';
 
-import { BaseNodeJsProps, LambdaConfig, LogGroupSubscriberType } from './types';
+import { BaseNodeJsProps, LambdaConfig, LogGroupSubscriberArnType } from './types';
 
 // CDK L2 constructs
 // Docs: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html#entry
@@ -34,7 +34,7 @@ import { BaseNodeJsProps, LambdaConfig, LogGroupSubscriberType } from './types';
  *   - allowAllOutbound is false by default. Use allowOutboundTo to specify hosts
  *   - source code path standardization to "[basePath]/[lambdaEventType]/[lambdaName]/index.ts" (can be overwritten by explicit props.entry)
  *   - custom CA support for HTTP calls (NodeJS NODE_EXTRA_CA_CERTS). See props.extraCaPubCert
- *   - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriber
+ *   - option to subscribe an Lambda Arn to the log group related to the Lambda function. See props.logGroupSubscriberArn
  *   - adds environment STAGE to Lambda. See props.stage
  */
 export class BaseNodeJsFunction extends Construct {
@@ -137,8 +137,8 @@ export const getPropsWithDefaults = (
     // eslint-disable-next-line prefer-destructuring
     createDefaultLogGroup = props.createDefaultLogGroup;
   }
-  if (!createDefaultLogGroup && props.logGroupSubscriber) {
-    throw new Error(`'logGroupSubscriber' cannot be used if 'createDefaultLogGroup' is false`);
+  if (!createDefaultLogGroup && props.logGroupSubscriberArn) {
+    throw new Error(`'logGroupSubscriberArn' cannot be used if 'createDefaultLogGroup' is false`);
   }
 
   let { entry } = props;
@@ -254,14 +254,14 @@ const addLogSubscriber = (
   nodeJsFunction: NodejsFunction,
   props: LambdaConfig,
 ): void => {
-  if (!props.logGroupSubscriber) {
+  if (!props.logGroupSubscriberArn) {
     return;
   }
 
   const functionArn =
-    props.logGroupSubscriber.type === LogGroupSubscriberType.Arn
-      ? props.logGroupSubscriber.value
-      : StringParameter.valueForStringParameter(scope, props.logGroupSubscriber.value);
+    props.logGroupSubscriberArn.type === LogGroupSubscriberArnType.Arn
+      ? props.logGroupSubscriberArn.value
+      : StringParameter.valueForStringParameter(scope, props.logGroupSubscriberArn.value);
 
   const logGroupFuncSubscriber = Function.fromFunctionAttributes(
     nodeJsFunction,

--- a/lib/src/lambda/types.ts
+++ b/lib/src/lambda/types.ts
@@ -94,7 +94,7 @@ export type LambdaConfig = Omit<
    * Register a Lambda as a subscriber of the default log group
    * @default none
    */
-  logGroupSubscriber?: LogGroupSubscriber;
+  logGroupSubscriberArn?: LogGroupSubscriberArn;
   /**
    * Create an alias named "live" that points to the latest version of this function
    * @defaults true
@@ -107,12 +107,12 @@ export type LambdaConfig = Omit<
  * It will create a `AWS::Logs::SubscriptionFilter` resource
  * This resource will trigger the configured function with all the logs generated in the deployed function
  */
-export type LogGroupSubscriber = {
-  type: LogGroupSubscriberType;
+export type LogGroupSubscriberArn = {
+  type: LogGroupSubscriberArnType;
   value: string;
 };
 
-export enum LogGroupSubscriberType {
+export enum LogGroupSubscriberArnType {
   /** The Arn of the Lambda function that will subscribe to the log group */
   Arn = 'arn',
   /** The AWS Systems Manager Parameter Store name that points to the Arn of the Lambda function that will subscribe to the log group */

--- a/lib/src/lambda/types.ts
+++ b/lib/src/lambda/types.ts
@@ -91,16 +91,33 @@ export type LambdaConfig = Omit<
    */
   logGroupRemovalPolicy?: RemovalPolicy;
   /**
-   * Register this lambda Arn as a subscriber of the default log group.
+   * Register this lambda as a subscriber of the default log group.
    * @default none
    */
-  logGroupSubscriberLambdaArn?: string;
+  logGroupSubscriber?: LogGroupSubscriber;
   /**
    * Create an alias named "live" that points to the latest version of this function
    * @defaults true
    */
   createLiveAlias?: boolean;
 };
+
+/**
+ * Log group subscriber configuration
+ * It will create a `AWS::Logs::SubscriptionFilter` resource
+ * This resource will trigger the configured function with all the logs generated in the deploying function
+ */
+export type LogGroupSubscriber = {
+  type: LogGroupSubscriberType;
+  value: string;
+};
+
+export enum LogGroupSubscriberType {
+  /** The lambda arn to be subscribed */
+  Arn = 'arn',
+  /** The SSM string parameter store key containing the lambda arn to be subscribed */
+  Ssm = 'ssm',
+}
 
 export enum EventType {
   Cloudwatch = 'cloudwatch',

--- a/lib/src/lambda/types.ts
+++ b/lib/src/lambda/types.ts
@@ -91,7 +91,7 @@ export type LambdaConfig = Omit<
    */
   logGroupRemovalPolicy?: RemovalPolicy;
   /**
-   * Register this lambda as a subscriber of the default log group.
+   * Register a Lambda as a subscriber of the default log group
    * @default none
    */
   logGroupSubscriber?: LogGroupSubscriber;
@@ -105,7 +105,7 @@ export type LambdaConfig = Omit<
 /**
  * Log group subscriber configuration
  * It will create a `AWS::Logs::SubscriptionFilter` resource
- * This resource will trigger the configured function with all the logs generated in the deploying function
+ * This resource will trigger the configured function with all the logs generated in the deployed function
  */
 export type LogGroupSubscriber = {
   type: LogGroupSubscriberType;
@@ -113,9 +113,9 @@ export type LogGroupSubscriber = {
 };
 
 export enum LogGroupSubscriberType {
-  /** The lambda arn to be subscribed */
+  /** The Arn of the Lambda function that will subscribe to the log group */
   Arn = 'arn',
-  /** The SSM string parameter store key containing the lambda arn to be subscribed */
+  /** The AWS Systems Manager Parameter Store name that points to the Arn of the Lambda function that will subscribe to the log group */
   Ssm = 'ssm',
 }
 

--- a/lib/src/wso2/types.ts
+++ b/lib/src/wso2/types.ts
@@ -15,7 +15,7 @@ export type Wso2LambdaConfig = Pick<
   | 'securityGroups'
   | 'extraCaPubCert'
   | 'network'
-  | 'logGroupSubscriber'
+  | 'logGroupSubscriberArn'
   | 'logGroupRetention'
   | 'logGroupRemovalPolicy'
 >;

--- a/lib/src/wso2/types.ts
+++ b/lib/src/wso2/types.ts
@@ -15,7 +15,7 @@ export type Wso2LambdaConfig = Pick<
   | 'securityGroups'
   | 'extraCaPubCert'
   | 'network'
-  | 'logGroupSubscriberLambdaArn'
+  | 'logGroupSubscriber'
   | 'logGroupRetention'
   | 'logGroupRemovalPolicy'
 >;


### PR DESCRIPTION
## Summary

Add the ability to pass an ssm string parameter to the `logGroupSubscriber` property.


### Motivation
In our scenario we have one stack that handles the log group subscription, and to avoid stack output dependency, we store the lambda arn into the system manager's parameter store as a string parameter.

To avoid having to fetch it on every lambda construct we have, it would be nice if we could just provide the parameter key for the construct  and it fetches the arn from ssm.


### Changes
I changed the lambda's construct property from `logGroupSubscriberLambdaArn ` to `logGroupSubscriber ` as we may receive a ssm key now.
I changed its datatype as well, from string to an object with the following definition:
```ts
{
    type: 'ssm' | 'arn';
    value: string;
}
```

It is a bit verbose but very explicit, please, let me know if you agree with this definition.

P.S.: I'd rather have the union type instead of enum, but I kept it as enum to follow the project standards.