### PR TITLE
feat: zod and zod-to-openapi peer dependencies

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -21,13 +21,13 @@
     "typescript": "5.3.3"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^6.3.1",
+    "@asteasolutions/zod-to-openapi": "^7.0.0",
     "aws-cdk-lib": "2.117.0",
     "aws-lambda": "^1.0.7",
     "cdk-practical-constructs": "file:../lib/dist/cdk-practical-constructs-0.0.1.tgz",
     "constructs": "^10.3.0",
     "esbuild": "^0.19.11",
     "openapi3-ts": "^4.2.1",
-    "zod": "^3.22.4"
+    "zod": "^3.23.8"
   }
 }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@asteasolutions/zod-to-openapi':
-    specifier: ^6.3.1
-    version: 6.3.1(zod@3.22.4)
+    specifier: ^7.0.0
+    version: 7.0.0(zod@3.23.8)
   aws-cdk-lib:
     specifier: 2.117.0
     version: 2.117.0(constructs@10.3.0)
@@ -16,7 +16,7 @@ dependencies:
     version: 1.0.7
   cdk-practical-constructs:
     specifier: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
-    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
+    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8)
   constructs:
     specifier: ^10.3.0
     version: 10.3.0
@@ -27,13 +27,13 @@ dependencies:
     specifier: ^4.2.1
     version: 4.2.1
   zod:
-    specifier: ^3.22.4
-    version: 3.22.4
+    specifier: ^3.23.8
+    version: 3.23.8
 
 devDependencies:
   '@stutzlab/eslint-config':
     specifier: ^3.0.4
-    version: 3.0.4(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb-typescript@17.1.0)(eslint-config-prettier@8.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-fp@2.3.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jest@27.9.0)(eslint-plugin-prettier@4.2.1)(eslint-plugin-promise@6.1.1)(eslint@8.57.0)(prettier@2.8.8)
+    version: 3.0.4(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb-typescript@17.1.0)(eslint-config-prettier@8.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-fp@2.3.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jest@27.9.0)(eslint-plugin-prettier@4.2.1)(eslint-plugin-promise@6.2.0)(eslint@8.57.0)(prettier@2.8.8)
   '@tsconfig/node16':
     specifier: 16.1.1
     version: 16.1.1
@@ -92,13 +92,13 @@ packages:
       typescript: 4.9.5
     dev: false
 
-  /@asteasolutions/zod-to-openapi@6.3.1(zod@3.22.4):
-    resolution: {integrity: sha512-1CRWBqslgdBpZeJnxxksGirAQ39Iztxk+LzTkYwoP0mNzuaULa604s8Xc5V9yzmYccwJ89O9fPQgxCkbNN398g==}
+  /@asteasolutions/zod-to-openapi@7.0.0(zod@3.23.8):
+    resolution: {integrity: sha512-rJRKHD2m6nUb/9ZheeN8nqOURX24WTzY8Sex1ZKT0Kpx+xfpRcD0fTD6vEeXNHGaDGxzu65Jj/jb2x6nLTjcMw==}
     peerDependencies:
       zod: ^3.20.2
     dependencies:
       openapi3-ts: 4.2.1
-      zod: 3.22.4
+      zod: 3.23.8
     dev: false
 
   /@asyncapi/specs@4.3.1:
@@ -2255,7 +2255,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@stutzlab/eslint-config@3.0.4(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb-typescript@17.1.0)(eslint-config-prettier@8.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-fp@2.3.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jest@27.9.0)(eslint-plugin-prettier@4.2.1)(eslint-plugin-promise@6.1.1)(eslint@8.57.0)(prettier@2.8.8):
+  /@stutzlab/eslint-config@3.0.4(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb-typescript@17.1.0)(eslint-config-prettier@8.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-fp@2.3.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jest@27.9.0)(eslint-plugin-prettier@4.2.1)(eslint-plugin-promise@6.2.0)(eslint@8.57.0)(prettier@2.8.8):
     resolution: {integrity: sha512-zLR1McZmJ66gjOJiOOilcVQqKjuIUwmh9vO7qHfHX/5nxvSeNi2NpnXwIu1JYlqVxeqfEm0fWMqT5zaquDRqWQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.53.0
@@ -2283,7 +2283,7 @@ packages:
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
-      eslint-plugin-promise: 6.1.1(eslint@8.57.0)
+      eslint-plugin-promise: 6.2.0(eslint@8.57.0)
       prettier: 2.8.8
     dev: true
 
@@ -4050,11 +4050,11 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-promise@6.1.1(eslint@8.57.0):
-    resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
+  /eslint-plugin-promise@6.2.0(eslint@8.57.0):
+    resolution: {integrity: sha512-QmAqwizauvnKOlifxyDj2ObfULpHQawlg/zQdgEixur9vl0CvZGv/LCJV2rtj3210QCoeGBzVMfMXqGAOr/4fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
     dependencies:
       eslint: 8.57.0
     dev: true
@@ -7458,17 +7458,21 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+  /zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz:
-    resolution: {integrity: sha512-SA7HBtCwSH/4oYMtTRmCUfZgqOaBNEpkbeXX7waeJr8nRuduw/ptLdfHRPCJtPde5grVKQNqfveUQ6uAQrl8Og==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8):
+    resolution: {integrity: sha512-P+5A+hkFbHgkMNE0Qp96y+E6yKFgRfjrJOkXSSu/h30NsmlyDZ5WYEmb5ukM8u8/pt5HNK+1AFJdnoE3LuZI7A==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+    id: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
     name: cdk-practical-constructs
     version: 0.0.1
+    peerDependencies:
+      '@asteasolutions/zod-to-openapi': 7.x
+      zod: 3.x
     dependencies:
       '@apiture/openapi-down-convert': 0.9.0
-      '@asteasolutions/zod-to-openapi': 6.3.1(zod@3.22.4)
+      '@asteasolutions/zod-to-openapi': 7.0.0(zod@3.23.8)
       '@aws-sdk/client-secrets-manager': 3.496.0
       '@stoplight/spectral-cli': 6.11.0
       aws-cdk-lib: 2.117.0(constructs@10.3.0)
@@ -7486,7 +7490,7 @@ packages:
       qs: 6.11.2
       scoperjs: 1.0.1
       tmp: 0.2.1
-      zod: 3.22.4
+      zod: 3.23.8
     transitivePeerDependencies:
       - aws-crt
       - debug

--- a/lib/package.json
+++ b/lib/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@apiture/openapi-down-convert": "^0.9.0",
-    "@asteasolutions/zod-to-openapi": "^6.3.1",
+    "@asteasolutions/zod-to-openapi": "^7.0.0",
     "@aws-sdk/client-secrets-manager": "^3.495.0",
     "@stoplight/spectral-cli": "^6.11.0",
     "aws-cdk-lib": "2.117.0",
@@ -60,7 +60,11 @@
     "qs": "^6.11.2",
     "scoperjs": "^1.0.1",
     "tmp": "^0.2.1",
-    "zod": "^3.22.4"
+    "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "zod": "3.x",
+    "@asteasolutions/zod-to-openapi": "7.x"
   },
   "publishConfig": {
     "access": "public",

--- a/lib/pnpm-lock.yaml
+++ b/lib/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^0.9.0
     version: 0.9.0
   '@asteasolutions/zod-to-openapi':
-    specifier: ^6.3.1
-    version: 6.3.1(zod@3.22.4)
+    specifier: ^7.0.0
+    version: 7.0.0(zod@3.23.8)
   '@aws-sdk/client-secrets-manager':
     specifier: ^3.495.0
     version: 3.496.0
@@ -63,8 +63,8 @@ dependencies:
     specifier: ^0.2.1
     version: 0.2.1
   zod:
-    specifier: ^3.22.4
-    version: 3.22.4
+    specifier: ^3.23.8
+    version: 3.23.8
 
 devDependencies:
   '@babel/preset-typescript':
@@ -143,13 +143,13 @@ packages:
       typescript: 4.9.5
     dev: false
 
-  /@asteasolutions/zod-to-openapi@6.3.1(zod@3.22.4):
-    resolution: {integrity: sha512-1CRWBqslgdBpZeJnxxksGirAQ39Iztxk+LzTkYwoP0mNzuaULa604s8Xc5V9yzmYccwJ89O9fPQgxCkbNN398g==}
+  /@asteasolutions/zod-to-openapi@7.0.0(zod@3.23.8):
+    resolution: {integrity: sha512-rJRKHD2m6nUb/9ZheeN8nqOURX24WTzY8Sex1ZKT0Kpx+xfpRcD0fTD6vEeXNHGaDGxzu65Jj/jb2x6nLTjcMw==}
     peerDependencies:
       zod: ^3.20.2
     dependencies:
       openapi3-ts: 4.2.1
-      zod: 3.22.4
+      zod: 3.23.8
     dev: false
 
   /@asyncapi/specs@4.3.1:
@@ -7128,6 +7128,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+  /zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false


### PR DESCRIPTION
## Summary 

Add `zod` and `zod-to-openapi` libraries as peer dependencies, so we don't require the projects to use the same version we use.

Zod breaks a lot the interfaces between minor versions, so it is important to use the same version as defined in the host package.