### PR TITLE
Feat/wait for update openapi document

### DIFF
--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: 1.0.7
   cdk-practical-constructs:
     specifier: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
-    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
+    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8)
   constructs:
     specifier: ^10.3.0
     version: 10.3.0
@@ -90,15 +90,6 @@ packages:
       commander: 9.5.0
       js-yaml: 4.1.0
       typescript: 4.9.5
-    dev: false
-
-  /@asteasolutions/zod-to-openapi@6.4.0(zod@3.23.8):
-    resolution: {integrity: sha512-8cxfF7AHHx2PqnN4Cd8/O8CBu/nVYJP9DpnfVLW3BFb66VJDnqI/CczZnkqMc3SNh6J9GiX7JbJ5T4BSP4HZ2Q==}
-    peerDependencies:
-      zod: ^3.20.2
-    dependencies:
-      openapi3-ts: 4.2.1
-      zod: 3.23.8
     dev: false
 
   /@asteasolutions/zod-to-openapi@7.0.0(zod@3.23.8):
@@ -7483,13 +7474,17 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz:
-    resolution: {integrity: sha512-x7QO2bP62EZlypCqVr6SkaV+vqnhx3UMJc76OB+1iqDStC8b5mafxbWWuTyDA8UTMRnpY6ximIVFd6LJh+k1lQ==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8):
+    resolution: {integrity: sha512-/BtEajTED991xxpmSfNoHjQ/qpli8B644trzBJsOubMReF6luwfL9b79biGDvY8otoNb9ZWFmiUBUNSvA5zsSA==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+    id: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
     name: cdk-practical-constructs
     version: 0.0.1
+    peerDependencies:
+      '@asteasolutions/zod-to-openapi': 7.x
+      zod: 3.x
     dependencies:
       '@apiture/openapi-down-convert': 0.9.0
-      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.23.8)
+      '@asteasolutions/zod-to-openapi': 7.0.0(zod@3.23.8)
       '@aws-sdk/client-secrets-manager': 3.496.0
       '@stoplight/spectral-cli': 6.11.0
       aws-cdk-lib: 2.117.0(constructs@10.3.0)

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: 1.0.7
   cdk-practical-constructs:
     specifier: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
-    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8)
+    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
   constructs:
     specifier: ^10.3.0
     version: 10.3.0
@@ -90,6 +90,15 @@ packages:
       commander: 9.5.0
       js-yaml: 4.1.0
       typescript: 4.9.5
+    dev: false
+
+  /@asteasolutions/zod-to-openapi@6.4.0(zod@3.23.8):
+    resolution: {integrity: sha512-8cxfF7AHHx2PqnN4Cd8/O8CBu/nVYJP9DpnfVLW3BFb66VJDnqI/CczZnkqMc3SNh6J9GiX7JbJ5T4BSP4HZ2Q==}
+    peerDependencies:
+      zod: ^3.20.2
+    dependencies:
+      openapi3-ts: 4.2.1
+      zod: 3.23.8
     dev: false
 
   /@asteasolutions/zod-to-openapi@7.0.0(zod@3.23.8):
@@ -2451,7 +2460,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -2476,7 +2485,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -2503,7 +2512,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
@@ -2527,7 +2536,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -3449,6 +3458,18 @@ packages:
       ms: 2.1.2
     dev: true
 
+  /debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
   /decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -3888,7 +3909,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
@@ -7462,17 +7483,13 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8):
-    resolution: {integrity: sha512-P+5A+hkFbHgkMNE0Qp96y+E6yKFgRfjrJOkXSSu/h30NsmlyDZ5WYEmb5ukM8u8/pt5HNK+1AFJdnoE3LuZI7A==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
-    id: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
+  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz:
+    resolution: {integrity: sha512-x7QO2bP62EZlypCqVr6SkaV+vqnhx3UMJc76OB+1iqDStC8b5mafxbWWuTyDA8UTMRnpY6ximIVFd6LJh+k1lQ==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
     name: cdk-practical-constructs
     version: 0.0.1
-    peerDependencies:
-      '@asteasolutions/zod-to-openapi': 7.x
-      zod: 3.x
     dependencies:
       '@apiture/openapi-down-convert': 0.9.0
-      '@asteasolutions/zod-to-openapi': 7.0.0(zod@3.23.8)
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.23.8)
       '@aws-sdk/client-secrets-manager': 3.496.0
       '@stoplight/spectral-cli': 6.11.0
       aws-cdk-lib: 2.117.0(constructs@10.3.0)

--- a/lib/src/wso2/utils.ts
+++ b/lib/src/wso2/utils.ts
@@ -36,7 +36,7 @@ export const addLambdaAndProviderForWso2Operations = (args: {
   const customResourceFunction = new BaseNodeJsFunction(args.scope, `${args.id}-custom-lambda`, {
     ...args.props.customResourceConfig,
     stage: 'wso2-custom-lambda',
-    timeout: Duration.minutes(5),
+    timeout: Duration.minutes(10),
     memorySize: 256,
     runtime: Runtime.NODEJS_18_X,
     eventType: EventType.CustomResource,

--- a/lib/src/wso2/wso2-api/handler/index.test.ts
+++ b/lib/src/wso2/wso2-api/handler/index.test.ts
@@ -99,7 +99,7 @@ describe('wso2 custom resource lambda', () => {
     nock(baseWso2Url)
       .get(/.*\/publisher\/v1\/apis$/)
       .query(true)
-      .times(1) // check create or update
+      .times(2) // check overlap, check create or update
       .reply(200, toResultList({ ...testDefs, lastUpdatedTime: '2020-10-10' }));
 
     nock(baseWso2Url)
@@ -116,7 +116,7 @@ describe('wso2 custom resource lambda', () => {
     // api get mock
     nock(baseWso2Url)
       .get(/.*\/publisher\/v1\/apis\/.*$/)
-      .times(1) // check if content matches
+      .times(2) // check overlap, check if content matches
       .reply(200, { ...testDefs, lastUpdatedTime: '2020-10-10' });
 
     nock(baseWso2Url)
@@ -146,13 +146,13 @@ describe('wso2 custom resource lambda', () => {
     nock(baseWso2Url)
       .get(/.*\/publisher\/v1\/apis$/)
       .query(true)
-      .times(3) // check create or update, check if updated, check if published
+      .times(4) // check overlap, check create or update, check if updated, check if published
       .reply(200, toResultList(testDefs));
 
     // api get mock
     nock(baseWso2Url)
       .get(/.*\/publisher\/v1\/apis\/.*$/)
-      .times(1) // check if content matches
+      .times(2) // check overlap, check if content matches
       .reply(200, { ...testDefs, lastUpdatedTime: '2020-10-10' });
 
     nock(baseWso2Url)
@@ -191,8 +191,14 @@ describe('wso2 custom resource lambda', () => {
     nock(baseWso2Url)
       .get(/.*\/publisher\/v1\/apis$/)
       .query(true)
-      .times(1) // check create or update
+      .times(2) // check overlap, create or update
       .reply(200, toResultList(testDefs));
+
+    // api get mock (check overlap fields)
+    nock(baseWso2Url)
+      .get(/.*\/publisher\/v1\/apis\/.*$/)
+      .times(1) // check if content matches
+      .reply(200, { ...testDefs, lastUpdatedTime: '2020-10-10' });
 
     // api update mock
     nock(baseWso2Url)


### PR DESCRIPTION
## Summary

WSO2 has a few overlap fields between the api definition and the openapi document.
We already check for those changes in the `checkWSO2Equivalence` method, but it seems to take a while to propagate to the openapi document. If update the openapi document right after updating the api defs, the changes may not be propagated and the final version will not reflect the new definitions.

It is an known issue, take a look in these discussions from serverless apim plugin:
- https://github.com/ramgrandhi/serverless-wso2-apim/issues/99
- https://github.com/ramgrandhi/serverless-wso2-apim/pull/114
- https://github.com/ramgrandhi/serverless-wso2-apim/pull/119

## What was changed?

I added a function in the beginning of the deployment to check if there are changes in these overlap fields.
If so, we hang for 2 minutes before updating the openapi document... As far as I tested, 2 minutes is more than enough to WSO2 propagate all the info.