### PR TITLE
fix: wso2 deployment checks agains empty objects

### DIFF
--- a/lib/src/wso2/wso2-api/handler/wso2-v1.test.ts
+++ b/lib/src/wso2/wso2-api/handler/wso2-v1.test.ts
@@ -130,5 +130,27 @@ describe('wso2 v1', () => {
         },
       ]);
     });
+
+    it('should handle empty objects when checking equivalence', () => {
+      const wso2apiData = {
+        ...petstoreFetchDataWso2Api,
+        businessInformation: {},
+        endpointConfig: {},
+        additionalProperties: {},
+        corsConfiguration: {},
+      };
+
+      const constructApiDefinition = {
+        ...petstoreFetchDataWso2Api,
+        businessInformation: {},
+        endpointConfig: {},
+        additionalProperties: {},
+        corsConfiguration: {},
+      };
+
+      // @ts-expect-error - Testing with empty objects
+      const result = checkWSO2Equivalence(wso2apiData, constructApiDefinition);
+      expect(result.isEquivalent).toBeTruthy();
+    });
   });
 });

--- a/lib/src/wso2/wso2-api/handler/wso2-v1.ts
+++ b/lib/src/wso2/wso2-api/handler/wso2-v1.ts
@@ -13,7 +13,11 @@ import {
   Wso2ApiDefinitionV1,
   Wso2ApiListV1,
 } from '../v1/types';
-import { areAttributeNamesEqual, normalizeCorsConfigurationValues } from '../utils';
+import {
+  areAttributeNamesEqual,
+  normalizeCorsConfigurationValues,
+  objectWithContentOrUndefined,
+} from '../utils';
 import { RetryOptions } from '../../types';
 
 export const findWso2Api = async (args: {
@@ -409,8 +413,8 @@ export const checkWSO2Equivalence = (
     {
       name: 'businessInformation',
       check: isEqual(
-        wso2ApiDefinition.businessInformation,
-        constructApiDefinition.businessInformation,
+        objectWithContentOrUndefined(wso2ApiDefinition.businessInformation),
+        objectWithContentOrUndefined(constructApiDefinition.businessInformation),
       ),
       data: {
         inWso2: wso2ApiDefinition.businessInformation,
@@ -419,7 +423,10 @@ export const checkWSO2Equivalence = (
     },
     {
       name: 'endpointConfig',
-      check: isEqual(wso2ApiDefinition.endpointConfig, constructApiDefinition.endpointConfig),
+      check: isEqual(
+        objectWithContentOrUndefined(wso2ApiDefinition.endpointConfig),
+        objectWithContentOrUndefined(constructApiDefinition.endpointConfig),
+      ),
       data: {
         inWso2: wso2ApiDefinition.endpointConfig,
         toBeDeployed: constructApiDefinition.endpointConfig,
@@ -428,8 +435,8 @@ export const checkWSO2Equivalence = (
     {
       name: 'additionalProperties',
       check: isEqual(
-        wso2ApiDefinition.additionalProperties,
-        constructApiDefinition.additionalProperties,
+        objectWithContentOrUndefined(wso2ApiDefinition.additionalProperties),
+        objectWithContentOrUndefined(constructApiDefinition.additionalProperties),
       ),
       data: {
         inWso2: wso2ApiDefinition.additionalProperties,
@@ -440,7 +447,7 @@ export const checkWSO2Equivalence = (
       name: 'corsConfiguration',
       check: isEqual(
         normalizeCorsConfigurationValues(wso2ApiDefinition.corsConfiguration),
-        constructApiDefinition.corsConfiguration,
+        objectWithContentOrUndefined(constructApiDefinition.corsConfiguration),
       ),
       data: {
         inWso2: normalizeCorsConfigurationValues(wso2ApiDefinition.corsConfiguration),

--- a/lib/src/wso2/wso2-api/utils.test.ts
+++ b/lib/src/wso2/wso2-api/utils.test.ts
@@ -85,4 +85,10 @@ describe('normalizeCorsConfigurationValues', () => {
     const result = normalizeCorsConfigurationValues(undefined);
     expect(result).toBeUndefined();
   });
+
+  it('should return undefined if configuration is empty', () => {
+    // @ts-expect-error - Testing for undefined
+    const result = normalizeCorsConfigurationValues({});
+    expect(result).toBeUndefined();
+  });
 });

--- a/lib/src/wso2/wso2-api/utils.ts
+++ b/lib/src/wso2/wso2-api/utils.ts
@@ -49,18 +49,33 @@ type NormalizedCorsConfiguration = Omit<
 export const normalizeCorsConfigurationValues = (
   corsConfiguration?: APICorsConfiguration,
 ): undefined | NormalizedCorsConfiguration => {
-  if (!corsConfiguration) return corsConfiguration;
+  const corsConfigurationObject = objectWithContentOrUndefined(corsConfiguration);
+  if (!corsConfigurationObject) {
+    // eslint-disable-next-line no-undefined
+    return undefined;
+  }
 
   const { corsConfigurationEnabled, accessControlAllowCredentials, ...restCorsConfiguration } =
-    corsConfiguration;
+    corsConfigurationObject;
 
   return {
     ...restCorsConfiguration,
-    ...(typeof corsConfiguration.corsConfigurationEnabled === 'boolean' && {
-      corsConfigurationEnabled: String(corsConfiguration.corsConfigurationEnabled),
+    ...(typeof corsConfigurationEnabled === 'boolean' && {
+      corsConfigurationEnabled: String(corsConfigurationEnabled),
     }),
-    ...(typeof corsConfiguration.accessControlAllowCredentials === 'boolean' && {
-      accessControlAllowCredentials: String(corsConfiguration.accessControlAllowCredentials),
+    ...(typeof accessControlAllowCredentials === 'boolean' && {
+      accessControlAllowCredentials: String(accessControlAllowCredentials),
     }),
   };
+};
+
+/**
+ * This function checks if the object has content or nor and only returns the object if it has content
+ */
+export const objectWithContentOrUndefined = <T>(obj: T): T | undefined => {
+  if (!obj || typeof obj !== 'object' || !Object.keys(obj).length) {
+    // eslint-disable-next-line no-undefined
+    return undefined;
+  }
+  return obj;
 };


### PR DESCRIPTION
## Summary

In some situation we may have a partial data in wso2, like an empty object.
It shouldn't prevent us from keeping deploying!

```
Received response status [FAILED] from custom resource. 
Message returned: Error: Some contents from the current deployed WSO2
api are different from the ones defined to be deployed:
[{"name":"additionalProperties","data":{"inWso2":{}}}]
```

![image](https://github.com/flaviostutz/cdk-practical-constructs/assets/34343596/fb5df7d3-beaf-4195-b1c3-7261924e7286)

Add the capability to ignore diffs from empty objects.