### PR TITLE
feat: update `aws-cdk-lib` and make it peer dependency

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,7 @@
     "@types/aws-lambda": "^8.10.131",
     "@types/jest": "^29.4.0",
     "@types/node": "^20.14.8",
-    "aws-cdk": "2.117.0",
+    "aws-cdk": "^2.155.0",
     "aws-sdk-client-mock": "^3.0.1",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.56.0",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.0.0",
-    "aws-cdk-lib": "2.117.0",
+    "aws-cdk-lib": "^2.155.0",
     "aws-lambda": "^1.0.7",
     "cdk-practical-constructs": "file:../lib/dist/cdk-practical-constructs-0.0.1.tgz",
     "constructs": "^10.3.0",

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -9,14 +9,14 @@ dependencies:
     specifier: ^7.0.0
     version: 7.0.0(zod@3.23.8)
   aws-cdk-lib:
-    specifier: 2.117.0
-    version: 2.117.0(constructs@10.3.0)
+    specifier: ^2.155.0
+    version: 2.155.0(constructs@10.3.0)
   aws-lambda:
     specifier: ^1.0.7
     version: 1.0.7
   cdk-practical-constructs:
     specifier: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
-    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8)
+    version: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(aws-cdk-lib@2.155.0)(zod@3.23.8)
   constructs:
     specifier: ^10.3.0
     version: 10.3.0
@@ -47,8 +47,8 @@ devDependencies:
     specifier: ^20.14.8
     version: 20.16.2
   aws-cdk:
-    specifier: 2.117.0
-    version: 2.117.0
+    specifier: ^2.155.0
+    version: 2.155.0
   aws-sdk-client-mock:
     specifier: ^3.0.1
     version: 3.0.1
@@ -115,9 +115,20 @@ packages:
     resolution: {integrity: sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==}
     dev: false
 
-  /@aws-cdk/asset-node-proxy-agent-v6@2.0.1:
-    resolution: {integrity: sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==}
+  /@aws-cdk/asset-node-proxy-agent-v6@2.0.3:
+    resolution: {integrity: sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==}
     dev: false
+
+  /@aws-cdk/cloud-assembly-schema@36.0.23:
+    resolution: {integrity: sha512-47gdj34MvEGG/Ewlx20Qs+HhJU4+b3rhttFuxeqxKZAiqCERYS+cCgQDdUhaeq+130v52n0g2+riPJ9AFI2ERg==}
+    engines: {node: '>= 18.18.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.3
+    dev: false
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   /@aws-crypto/sha256-browser@5.2.0:
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -2960,15 +2971,16 @@ packages:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  /aws-cdk-lib@2.117.0(constructs@10.3.0):
-    resolution: {integrity: sha512-My5T4hn34H6+tnZxKK2VlcvGI2N5SjqGt9lXWADcahdobuUcNizYrls7h/vcQ3BfwcZ5/tHTKtivkNyL8I1LDg==}
+  /aws-cdk-lib@2.155.0(constructs@10.3.0):
+    resolution: {integrity: sha512-QGzDhLldBXsyOUmhgtZ98PiOUS2g1Mb5MO08FiOvQn3+KSyJjQdq0GoyxtDpCNGLaWmIfcyrtB9aDhod38fl9g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.202
       '@aws-cdk/asset-kubectl-v20': 2.1.2
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.3
+      '@aws-cdk/cloud-assembly-schema': 36.0.23
       constructs: 10.3.0
     dev: false
     bundledDependencies:
@@ -2982,9 +2994,10 @@ packages:
       - semver
       - table
       - yaml
+      - mime-types
 
-  /aws-cdk@2.117.0:
-    resolution: {integrity: sha512-uuWT646vSRXZ/6don+wfK4kelV1aL4WOTduaihltRlXw4etHoMV3wJYBO30E6e8hAU+0HkLT7Fv58po50b12Sg==}
+  /aws-cdk@2.155.0:
+    resolution: {integrity: sha512-AV7Ym/o7/xyDh6sqcGatWD6Bqa7Swe0OWJq+1srVww0MdBiy5yM3zYAA1+ZeqZNjFQThJPA+pYZQFTgojuaVBA==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
     optionalDependencies:
@@ -5742,6 +5755,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /jsonschema@1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
+
   /just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
     dev: true
@@ -6619,7 +6636,6 @@ packages:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /set-function-length@1.2.0:
     resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
@@ -7441,20 +7457,21 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(zod@3.23.8):
-    resolution: {integrity: sha512-eU9q4KFtayefD7mzxXZgeqRRekSp1sipiUtnJ3/QVwvZNqZQ+vJ5pdXZG0Jj5rDLTdbiUc1QNaF4kBuDJUzHWw==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
+  file:../lib/dist/cdk-practical-constructs-0.0.1.tgz(@asteasolutions/zod-to-openapi@7.0.0)(aws-cdk-lib@2.155.0)(zod@3.23.8):
+    resolution: {integrity: sha512-ZKTk0nCY2DMvvSi0dPxlUXITsd2ahY6cN4GIXyRs+EB65HSmAQj/ftDJtOyy26zJ3MeVW/fzrGo2/5e5xROuNA==, tarball: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz}
     id: file:../lib/dist/cdk-practical-constructs-0.0.1.tgz
     name: cdk-practical-constructs
     version: 0.0.1
     peerDependencies:
       '@asteasolutions/zod-to-openapi': 7.x
+      aws-cdk-lib: 2.x
       zod: 3.x
     dependencies:
       '@apiture/openapi-down-convert': 0.9.0
       '@asteasolutions/zod-to-openapi': 7.0.0(zod@3.23.8)
       '@aws-sdk/client-secrets-manager': 3.624.0
       '@stoplight/spectral-cli': 6.11.1
-      aws-cdk-lib: 2.117.0(constructs@10.3.0)
+      aws-cdk-lib: 2.155.0(constructs@10.3.0)
       aws-lambda: 1.0.7
       axios: 1.7.5
       constructs: 10.3.0

--- a/lib/package.json
+++ b/lib/package.json
@@ -42,10 +42,8 @@
   },
   "dependencies": {
     "@apiture/openapi-down-convert": "^0.9.0",
-    "@asteasolutions/zod-to-openapi": "^7.0.0",
     "@aws-sdk/client-secrets-manager": "^3.624.0",
     "@stoplight/spectral-cli": "^6.11.1",
-    "aws-cdk-lib": "2.117.0",
     "aws-lambda": "^1.0.7",
     "axios": "^1.7.5",
     "constructs": "^10.3.0",
@@ -59,11 +57,11 @@
     "openapi3-ts": "^4.2.1",
     "qs": "^6.11.2",
     "scoperjs": "^1.0.1",
-    "tmp": "^0.2.1",
-    "zod": "^3.23.8"
+    "tmp": "^0.2.1"
   },
   "peerDependencies": {
     "@asteasolutions/zod-to-openapi": "7.x",
+    "aws-cdk-lib": "2.x",
     "zod": "3.x"
   },
   "publishConfig": {

--- a/lib/pnpm-lock.yaml
+++ b/lib/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
     specifier: ^0.9.0
     version: 0.9.0
   '@asteasolutions/zod-to-openapi':
-    specifier: ^7.0.0
+    specifier: 7.x
     version: 7.0.0(zod@3.23.8)
   '@aws-sdk/client-secrets-manager':
     specifier: ^3.624.0
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^6.11.1
     version: 6.11.1
   aws-cdk-lib:
-    specifier: 2.117.0
-    version: 2.117.0(constructs@10.3.0)
+    specifier: 2.x
+    version: 2.155.0(constructs@10.3.0)
   aws-lambda:
     specifier: ^1.0.7
     version: 1.0.7
@@ -66,7 +66,7 @@ dependencies:
     specifier: ^0.2.1
     version: 0.2.1
   zod:
-    specifier: ^3.23.8
+    specifier: 3.x
     version: 3.23.8
 
 devDependencies:
@@ -169,9 +169,20 @@ packages:
     resolution: {integrity: sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==}
     dev: false
 
-  /@aws-cdk/asset-node-proxy-agent-v6@2.0.1:
-    resolution: {integrity: sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==}
+  /@aws-cdk/asset-node-proxy-agent-v6@2.0.3:
+    resolution: {integrity: sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==}
     dev: false
+
+  /@aws-cdk/cloud-assembly-schema@36.0.23:
+    resolution: {integrity: sha512-47gdj34MvEGG/Ewlx20Qs+HhJU4+b3rhttFuxeqxKZAiqCERYS+cCgQDdUhaeq+130v52n0g2+riPJ9AFI2ERg==}
+    engines: {node: '>= 18.18.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.3
+    dev: false
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   /@aws-crypto/sha256-browser@5.2.0:
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -2982,15 +2993,16 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
 
-  /aws-cdk-lib@2.117.0(constructs@10.3.0):
-    resolution: {integrity: sha512-My5T4hn34H6+tnZxKK2VlcvGI2N5SjqGt9lXWADcahdobuUcNizYrls7h/vcQ3BfwcZ5/tHTKtivkNyL8I1LDg==}
+  /aws-cdk-lib@2.155.0(constructs@10.3.0):
+    resolution: {integrity: sha512-QGzDhLldBXsyOUmhgtZ98PiOUS2g1Mb5MO08FiOvQn3+KSyJjQdq0GoyxtDpCNGLaWmIfcyrtB9aDhod38fl9g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.202
       '@aws-cdk/asset-kubectl-v20': 2.1.2
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.3
+      '@aws-cdk/cloud-assembly-schema': 36.0.23
       constructs: 10.3.0
     dev: false
     bundledDependencies:
@@ -3004,6 +3016,7 @@ packages:
       - semver
       - table
       - yaml
+      - mime-types
 
   /aws-lambda@1.0.7:
     resolution: {integrity: sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==}
@@ -5557,6 +5570,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /jsonschema@1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
+
   /just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
     dev: true
@@ -6417,6 +6434,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dev: true
+
+  /semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
 
   /set-function-length@1.2.0:
     resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}


### PR DESCRIPTION
## Summary
Make the `aws-cdk-lib` a peer dependency so we don't force our users to be in the same versino as we defined in the this lib.

## Breaking changes

It might have breaking change as I bumped the cdk lib version, all the tests passed and examples worked fine though.

## Closing issues

Fixes #28 
