### PR TITLE
feat: return success on 404 error when deleting api

### DIFF
--- a/lib/src/wso2/wso2-api/handler/index.test.ts
+++ b/lib/src/wso2/wso2-api/handler/index.test.ts
@@ -381,6 +381,25 @@ describe('wso2 custom resource lambda', () => {
     expect(eres.Status).toBe('SUCCESS');
   });
 
+  it('should return success when api does not exists on DELETE operation', async () => {
+    nockBasicWso2SDK();
+
+    // api update mock
+    nock(baseWso2Url)
+      .delete(/.*\/publisher\/v1\/apis\/.*$/)
+      .reply(404);
+
+    const eres = await handler(
+      testCFNEventDelete(
+        {
+          ...testEvent,
+        },
+        '123-456',
+      ),
+    );
+    expect(eres.Status).toBe('SUCCESS');
+  });
+
   const toResultList = (apiDefs: PublisherPortalAPIv1): { list: ApiFromListV1[] } => {
     return {
       list: [

--- a/lib/src/wso2/wso2-api/handler/wso2-v1.ts
+++ b/lib/src/wso2/wso2-api/handler/wso2-v1.ts
@@ -93,7 +93,12 @@ export const removeApiInWso2 = async (args: {
   if (!args.wso2ApiId) {
     throw new Error('wso2ApiId is required for deleting API');
   }
-  await args.wso2Axios.delete(`/api/am/publisher/v1/apis/${args.wso2ApiId}`);
+  await args.wso2Axios.delete(`/api/am/publisher/v1/apis/${args.wso2ApiId}`, {
+    validateStatus(status) {
+      // If it returns 404, the api is already deleted
+      return status === 200 || status === 404;
+    },
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

To successfully delete a stack, the api must be deleted from WSO2 platform.
If the API is already deleted by any means, the stack deletion will fail because our 'delete' hook expect the delete operation to always be 2xx.

I added the success for 404 as well, so in case of the API is already deleted in the WSO2 platform it will not fail the stack deletion