### PR TITLE
fix(pnpm): pin pnpm version

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -33,7 +33,13 @@ clean:
 all: build lint test
 
 install:
-	corepack enable
+	# corepack enable
+
+	# To circunvent https://github.com/nodejs/corepack/issues/612
+	corepack enable pnpm
+	corepack use pnpm@8.9.0
+	COREPACK_INTEGRITY_KEYS=0 pnpm --version
+
 	pnpm install --frozen-lockfile --config.dedupe-peer-dependents=false
 
 publish:


### PR DESCRIPTION
## Summary

Pin pnpm version to avoid errors such as in https://github.com/nodejs/corepack/issues/612