### PR TITLE
Fixed security group config for WSO2 custom resource

### DIFF
--- a/lib/src/wso2/utils-cdk.ts
+++ b/lib/src/wso2/utils-cdk.ts
@@ -39,16 +39,13 @@ export const addLambdaAndProviderForWso2Operations = (args: {
   // vpc is undefined if no network is defined
   let vpc: IVpc | undefined;
 
-  const securityGroups = [];
+  const securityGroups = customResourceConfig?.securityGroups ?? [];
 
   // Create security group for custom resource if VPC is defined and no security group is defined
   if (args.props.customResourceConfig?.network) {
     vpc = vpcFromConfig(args.scope, args.props.customResourceConfig.network);
 
-    if (
-      !customResourceConfig?.securityGroups ||
-      customResourceConfig?.securityGroups.length === 0
-    ) {
+    if (securityGroups.length === 0) {
       // create default security group for the lambda function
       const securityGroup = new SecurityGroup(args.scope, `sg-cr-${args.scope.node.id}`, {
         vpc,

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "sourceMap": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "esModuleInterop": true
   },
   "include": ["src", ".eslintrc.js", "jest.config.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Together with Tom I fixed a bug in the WSO2 custom resource.

It creates a default security group if you specified a network config without security group.
But, if you passed your own security group, it's actually overridden by `const securityGroups = [];`
This PR fixes the issue.

Also, we added 2 unit tests to test this behaviour, because it wasn't covered by unit tests.
1 test with a network config without security group, and 1 test with a network config + explicit security group.

This allowed us to apply TDD to make the red test green to make sure we fixed the bug. :-)