### PR TITLE
Fix/WSO2 deployment when no lifecycle status is provided

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/client-secrets-manager": "^3.624.0",
     "@stoplight/spectral-cli": "^6.13.1",
     "aws-lambda": "^1.0.7",
-    "axios": "^1.7.5",
+    "axios": "^1.8.2",
     "constructs": "^10.3.0",
     "esbuild": "^0.19.11",
     "exponential-backoff": "^3.1.1",

--- a/lib/pnpm-lock.yaml
+++ b/lib/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^1.0.7
     version: 1.0.7
   axios:
-    specifier: ^1.7.5
-    version: 1.7.5
+    specifier: ^1.8.2
+    version: 1.8.2
   constructs:
     specifier: ^10.3.0
     version: 10.3.0
@@ -3228,8 +3228,8 @@ packages:
       xml2js: 0.5.0
     dev: false
 
-  /axios@1.7.5:
-    resolution: {integrity: sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==}
+  /axios@1.8.2:
+    resolution: {integrity: sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==}
     dependencies:
       follow-redirects: 1.15.6
       form-data: 4.0.0

--- a/lib/src/wso2/wso2-api/handler/index.ts
+++ b/lib/src/wso2/wso2-api/handler/index.ts
@@ -2,7 +2,6 @@
 import { AxiosInstance } from 'axios';
 import { CdkCustomResourceEvent, CdkCustomResourceResponse } from 'aws-lambda';
 
-import { PublisherPortalAPIv1 } from '../v1/types';
 import { Wso2ApiCustomResourceProperties } from '../types';
 import { prepareAxiosForWso2Calls } from '../../wso2-utils';
 import { applyRetryDefaults, truncateStr } from '../../utils';
@@ -10,6 +9,7 @@ import { applyRetryDefaults, truncateStr } from '../../utils';
 import {
   createUpdateAndChangeLifecycleStatusInWso2,
   findWso2Api,
+  getWso2Api,
   removeApiInWso2,
 } from './wso2-v1';
 
@@ -104,12 +104,12 @@ const createOrUpdateWso2Api = async (
   });
 
   let apiBeforeUpdate;
-  if (existingApi) {
+  if (existingApi && existingApi.id) {
     console.log(
       `Found existing WSO2 API. apiId=${existingApi.id}; name=${existingApi.name}; version=${existingApi.version} context=${existingApi.context}`,
     );
-    const apir = await wso2Axios.get(`/api/am/publisher/v1/apis/${existingApi.id}`);
-    apiBeforeUpdate = apir.data as PublisherPortalAPIv1;
+
+    apiBeforeUpdate = await getWso2Api({ wso2Axios, wso2ApiId: existingApi.id });
   }
 
   if (event.RequestType === 'Create' && existingApi && event.ResourceProperties.failIfExists) {

--- a/lib/src/wso2/wso2-api/handler/wso2-v1.ts
+++ b/lib/src/wso2/wso2-api/handler/wso2-v1.ts
@@ -73,6 +73,16 @@ export const findWso2Api = async (args: {
   );
 };
 
+export const getWso2Api = async (args: {
+  wso2Axios: AxiosInstance;
+  wso2ApiId: string;
+}): Promise<PublisherPortalAPIv1> => {
+  const apir = await args.wso2Axios.get<PublisherPortalAPIv1>(
+    `/api/am/publisher/v1/apis/${args.wso2ApiId}`,
+  );
+  return apir.data;
+};
+
 export type UpsertWso2Args = Pick<Wso2ApiProps, 'lifecycleStatus'> &
   Required<Pick<Wso2ApiProps, 'retryOptions' | 'openapiDocument' | 'apiDefinition'>> & {
     wso2Axios: AxiosInstance;
@@ -93,6 +103,7 @@ export const removeApiInWso2 = async (args: {
   if (!args.wso2ApiId) {
     throw new Error('wso2ApiId is required for deleting API');
   }
+
   await args.wso2Axios.delete(`/api/am/publisher/v1/apis/${args.wso2ApiId}`, {
     validateStatus(status) {
       // If it returns 404, the api is already deleted
@@ -158,27 +169,36 @@ export const createUpdateAndChangeLifecycleStatusInWso2 = async (
     );
   }
 
-  // get endpoint url
-  console.log(`Getting API endpoint url`);
-  const apir = await args.wso2Axios.get(`/api/am/store/v1/apis/${wso2ApiId}`);
+  let endpointUrl: string | undefined;
 
-  // DISABLING ENDPOINT URL WHILE WE FIX AN ISSUE
-  // find the endpoint URL of the environment that was defined in this API
-  const apid = apir.data as DevPortalAPIv1;
-  const endpointUrl = apid.endpointURLs?.reduce((acc, elem) => {
-    if (
-      elem.environmentName &&
-      args.apiDefinition.gatewayEnvironments?.includes(elem.environmentName)
-    ) {
-      if (elem.URLs?.https) {
-        return elem.URLs?.https;
+  const apiData = await getWso2Api({ wso2Axios: args.wso2Axios, wso2ApiId });
+
+  if (apiData.lifeCycleStatus === 'PUBLISHED') {
+    // get endpoint url
+    console.log(`Getting API endpoint url`);
+    const apiStoreData = await args.wso2Axios.get<DevPortalAPIv1>(
+      `/api/am/store/v1/apis/${wso2ApiId}`,
+    );
+
+    // DISABLING ENDPOINT URL WHILE WE FIX AN ISSUE
+    // find the endpoint URL of the environment that was defined in this API
+    endpointUrl = apiStoreData.data.endpointURLs?.reduce((acc, elem) => {
+      if (
+        elem.environmentName &&
+        args.apiDefinition.gatewayEnvironments?.includes(elem.environmentName)
+      ) {
+        if (elem.URLs?.https) {
+          return elem.URLs?.https;
+        }
+        if (elem.defaultVersionURLs?.https) {
+          return elem.defaultVersionURLs?.https;
+        }
       }
-      if (elem.defaultVersionURLs?.https) {
-        return elem.defaultVersionURLs?.https;
-      }
-    }
-    return acc;
-  }, '');
+      return acc;
+    }, '');
+  } else {
+    console.log('API is not published, skipping the endpoint URL retrieval');
+  }
 
   console.log('API created/updated successfully on WSO2 server');
 
@@ -346,14 +366,13 @@ const checkApiExistsAndMatches = async (
     wso2Tenant: args.wso2Tenant,
   });
 
-  if (!searchApi) {
+  if (!searchApi || !searchApi.id) {
     throw new Error(`API couldn't be found on WSO2`);
   }
 
   console.log(`API '${searchApi.id}' found in WSO2 search`);
 
-  const apir = await args.wso2Axios.get(`/api/am/publisher/v1/apis/${searchApi.id}`);
-  const apiDetails = apir.data as PublisherPortalAPIv1;
+  const apiDetails = await getWso2Api({ wso2Axios: args.wso2Axios, wso2ApiId: searchApi.id });
 
   if (!apiDetails.lastUpdatedTime) {
     throw new Error('lastUpdatedTime is null in api');
@@ -519,12 +538,11 @@ const checkApiDefAndOpenapiOverlap = async (args: UpsertWso2Args): Promise<boole
       wso2Tenant: args.wso2Tenant,
     });
 
-    if (!searchApi) {
+    if (!searchApi || !searchApi.id) {
       throw new Error('WSO2 API not found');
     }
 
-    const apir = await args.wso2Axios.get(`/api/am/publisher/v1/apis/${searchApi.id}`);
-    const apiDetails = apir.data as PublisherPortalAPIv1;
+    const apiDetails = await getWso2Api({ wso2Axios: args.wso2Axios, wso2ApiId: searchApi.id });
 
     const { isEquivalent } = checkWSO2Equivalence(apiDetails, args.apiDefinition);
 


### PR DESCRIPTION
## Summary

**Problems identified:**
- Only published APIs are available in the WSO2 dev portal platform.
- WSO2 platform may take while to propagate the published API to the dev portal platform.


**Changes introduced:**

- We fetch the current api data to check the api lifecycle status before trying to get the endpoint url from dev portal.
- We don't try to retrieve the endpoint url if the API is not published.
- We added backoff retry to the endpoint url retrieval to mitigate the possible dalay in the data propagation between the publisher and dev portals

## Breaking changes

none

## Closing issues

Fixes #67 
