### PR TITLE
feat: export generateOpenapiDocWithExtensions

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -2,7 +2,10 @@ export * from './utils';
 
 export * from './config/configs';
 
-export { OpenApiGatewayLambda } from './apigateway/openapi-gateway-lambda';
+export {
+  OpenApiGatewayLambda,
+  generateOpenapiDocWithExtensions,
+} from './apigateway/openapi-gateway-lambda';
 export * from './apigateway/types';
 
 export { BaseNodeJsFunction } from './lambda/lambda-base';


### PR DESCRIPTION
## Summary

There are use cases to generate the OpenAPI document and use this with WSO2 without creating the AWS API Gateway. 

This PR fixes/implements the following **bugs/features**

- [ ] Bug 1
- [X] Feature 1

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Exporting `generateOpenapiDocWithExtensions` function from `openapi-gateway-lambda.ts` to be used in instances where only OpenAPI document is needed.
