### PR TITLE
feat: add convertOpenapi31ToV30 function

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -5,6 +5,7 @@ export * from './config/configs';
 export {
   OpenApiGatewayLambda,
   generateOpenapiDocWithExtensions,
+  convertOpenapi31ToV30,
 } from './apigateway/openapi-gateway-lambda';
 export * from './apigateway/types';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request: -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

## Summary

<!-- Summary of the PR -->

Exporting the utility function to convert an OpenAPI 3.1 object to OpenAPI 3.0 object.

This PR fixes/implements the following **bugs/features**

- [ ] Bug 1
- [X] Feature 1

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This is useful when AWS Gateway is not created. The OpenAPI document should be created with `generateOpenapiDocWithExtensions` and converted to OpenAPI 3.0, as `Wso2API` construct supports 3.0 as of now.

## Breaking changes

None
