### PR TITLE
Dont override businessInformation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "singleQuote": true
+}

--- a/lib/src/wso2/wso2-api/api-defs.ts
+++ b/lib/src/wso2/wso2-api/api-defs.ts
@@ -170,17 +170,20 @@ const applyOpenapiAsDefaults = (
   apiDef: Wso2ApiDefinitionV1,
 ): Wso2ApiDefinitionV1 => {
   const apiDefr = { ...apiDef };
-  // user openapi contact info for business/technical information of the api
+  // use openapi contact info for business/technical information of the api
   if (
-    (!apiDefr.businessInformation && openapiDocument.info.contact?.email) ||
-    openapiDocument.info.contact?.name
+    !apiDefr.businessInformation &&
+    (openapiDocument.info.contact?.email || openapiDocument.info.contact?.name)
   ) {
-    apiDefr.businessInformation = {
-      businessOwnerEmail: openapiDocument.info.contact?.email,
-      technicalOwnerEmail: openapiDocument.info.contact?.email,
-      technicalOwner: openapiDocument.info.contact?.name,
-      businessOwner: openapiDocument.info.contact?.name,
-    };
+    apiDefr.businessInformation = {};
+    if (openapiDocument.info.contact?.email) {
+      apiDefr.businessInformation.businessOwnerEmail = openapiDocument.info.contact?.email;
+      apiDefr.businessInformation.technicalOwnerEmail = openapiDocument.info.contact?.email;
+    }
+    if (openapiDocument.info.contact?.name) {
+      apiDefr.businessInformation.businessOwner = openapiDocument.info.contact?.name;
+      apiDefr.businessInformation.technicalOwner = openapiDocument.info.contact?.name;
+    }
   }
 
   if (!apiDefr.description && openapiDocument.info.description) {


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

- Contact information from OpenAPI document takes precedence over user provided `businessInformation`, see #71 

Certain fields in the `wso2ApiDefinition` get defaults taken the OpenAPI document, which can be overridden by the user providing them in `wso2ApiDefinition`, for example the `description`, `version`, and `tags`.

The fields in `businessInformation` fields, `businessOwner`, `businessOwnerEmail`, `technicalOwner`, and `technicalOwnerEmail` however were always taken from the OpenAPI document whenever the OpenAPI document contains a `info.contact.email`, and were not overridable.

This PR takes defaults these fields from the OpenAPI document only when the user doesn't provide a `businessInformation` field.

## Closing issues

Fixes #72 


